### PR TITLE
Fix hexagon control change behaviour: ignore hexes that you already own

### DIFF
--- a/Assets/Scenes/FreddieTestScene.unity
+++ b/Assets/Scenes/FreddieTestScene.unity
@@ -425,6 +425,14 @@ PrefabInstance:
       propertyPath: unitController
       value: 
       objectReference: {fileID: 694091047}
+    - target: {fileID: 2740399969464054150, guid: a98cdba32fdef12468812fcf1f4b8d1c, type: 3}
+      propertyPath: gridData
+      value: 
+      objectReference: {fileID: 1533390224}
+    - target: {fileID: 2740399969464054150, guid: a98cdba32fdef12468812fcf1f4b8d1c, type: 3}
+      propertyPath: unitPlacement
+      value: 
+      objectReference: {fileID: 121099228}
     - target: {fileID: 3168967069251171779, guid: a98cdba32fdef12468812fcf1f4b8d1c, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -505,9 +513,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4423819880621845921, guid: a98cdba32fdef12468812fcf1f4b8d1c, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6548401546078417604, guid: a98cdba32fdef12468812fcf1f4b8d1c, type: 3}
       propertyPath: m_Name
       value: 'InGameUI '
+      objectReference: {fileID: 0}
+    - target: {fileID: 8809423467196657296, guid: a98cdba32fdef12468812fcf1f4b8d1c, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2388875677
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/GameEvents.cs
+++ b/Assets/Scripts/GameEvents.cs
@@ -59,8 +59,7 @@ public static class GameEvents
     {
         public UnityAction<ulong, FixedString32Bytes> OnPlayerConnected;
         public UnityAction<ulong, int> OnPlayerColorChanged;
-        public UnityAction<ulong, int> OnPlayerScoreChanged;
-        public UnityAction<AxialCoordinates, ulong> OnHexControllerChanged;
+        public UnityAction<AxialCoordinates, ulong> OnInitialPlayerUnitsPlaced;
     }
 }
 

--- a/Assets/Scripts/HexControlObserver.cs
+++ b/Assets/Scripts/HexControlObserver.cs
@@ -12,7 +12,7 @@ public class HexControlObserver : NetworkBehaviour
 
     public void InitializeOnServer()
     {
-        GameEvents.NETWORK_SERVER.OnHexControllerChanged += HandleHexControllerChanged;
+        GameEvents.NETWORK_SERVER.OnInitialPlayerUnitsPlaced += HandleHexControllerChanged;
         GameEvents.UNIT.OnUnitGroupReachedHexCenter += HandleUnitGroupReachedHexCenter;
     }
 
@@ -26,7 +26,9 @@ public class HexControlObserver : NetworkBehaviour
         {
             Debug.Log("Unit should become stationary");
             gridData.UpdateStationaryUnitGroupOfHex(hexCoordinates, unitGroup);
-            HandleHexControllerChanged(hexagonData.Coordinates, unitGroup.PlayerId);
+            if(gridData.GetHexagonDataOnCoordinate(hexCoordinates).ControllerPlayerId != unitGroup.PlayerId)
+                HandleHexControllerChanged(hexagonData.Coordinates, unitGroup.PlayerId);
+            
             return;
         }
 

--- a/Assets/Scripts/MatchStartup.cs
+++ b/Assets/Scripts/MatchStartup.cs
@@ -87,7 +87,7 @@ public class MatchStartup : NetworkBehaviour
             _remainingStartCoordinates.Remove(playerStartCoordinate);
             var playerStartHex = mapBuilder.Grid.Get(playerStartCoordinate);
             
-            GameEvents.NETWORK_SERVER.OnHexControllerChanged!.Invoke(playerStartCoordinate, playerData.ClientId);
+            GameEvents.NETWORK_SERVER.OnInitialPlayerUnitsPlaced!.Invoke(playerStartCoordinate, playerData.ClientId);
             unitPlacement.TryAddUnitsToHex(playerStartCoordinate, playerData, 30);
             
             var clientRpcParams = HelperMethods.GetClientRpcParamsToSingleTarget(playerData.ClientId);

--- a/Assets/Scripts/Networking/Host/PlayerDataStorage.cs
+++ b/Assets/Scripts/Networking/Host/PlayerDataStorage.cs
@@ -90,7 +90,6 @@ namespace Networking.Host
                 {
                     Debug.Log($"Player {PlayerName}, new score: {value}, old score: {_playerScore}");
                     _playerScore = value;
-                    GameEvents.NETWORK_SERVER.OnPlayerScoreChanged?.Invoke(ClientId, PlayerScore);
                 }
             }
 


### PR DESCRIPTION
Hex control change wurde getriggert auch wenn man sein eigenes Hex betreten hat. Das ist jetzt gefixed.