### PR TITLE
FixedSideStepAfterPause/Combat

### DIFF
--- a/Assets/Scripts/Core/Unit/Group/Movement.cs
+++ b/Assets/Scripts/Core/Unit/Group/Movement.cs
@@ -73,13 +73,13 @@ namespace Core.Unit.Group
         {
             _isPaused = pause;
             
-            if (!pause && HasMovementLeft)
+            if (!_isPaused && HasMovementLeft)
             {
                 _moveRoutine = StartCoroutine(MoveToGoal());
-                
+                transform.rotation = Quaternion.LookRotation(GoalHexagon.transform.position - transform.position);
                 OnMoveAnimationSpeedChangedClientRpc(_moveSpeed);
             }
-            else if (pause && _moveRoutine != null)
+            else if (_isPaused && _moveRoutine != null)
             {
                 StopCoroutine(_moveRoutine);
                 _moveRoutine = null;


### PR DESCRIPTION
If CombatCenter is not in the direction of the units movement, the unit used to move sideways after combat, as it did not turn back in the walking direction. This was fixed by turning the unit when the pause state changes.